### PR TITLE
[fix]#08 Remove unnecessary descriptions

### DIFF
--- a/laravel/tests/Feature/LoginApiTest.php
+++ b/laravel/tests/Feature/LoginApiTest.php
@@ -83,8 +83,6 @@ class LoginApiTest extends TestCase
     {
         $this->data['password'] = $this->faker->password(8);
 
-        \Log::info($this->data);
-
         $response = $this->postJson(route('login'), $this->data);
 
         $expected = [


### PR DESCRIPTION
不要な記述であったLoginApiTest.phpの\Log::info()を削除しました