### PR TITLE
[fix]#96 Fixed client_max_body_size in default.conf

### DIFF
--- a/infra/nginx/default.conf
+++ b/infra/nginx/default.conf
@@ -11,7 +11,7 @@ server {
 
     index index.html index.htm index.php;
 
-    client_max_body_size 2M;
+    client_max_body_size 50M;
 
     charset utf-8;
 


### PR DESCRIPTION
* `client_max_body_size`を50MBに変更し、php.iniの`upload_max_filesize`を上回るようにしました。