### PR TITLE
[fix]#184 Fixed push() and closeMenu() in Card.vue

### DIFF
--- a/laravel/resources/js/components/Card.vue
+++ b/laravel/resources/js/components/Card.vue
@@ -103,12 +103,12 @@ export default {
       }
     },
     push(e) {
-      if (this.$el.querySelector(`#open-button-${this.article.id}`).contains(e.target)) return;
+      if (this.ownedByMe && this.$el.querySelector(`#open-button-${this.article.id}`).contains(e.target)) return;
       this.$router.push(`/article/${this.article.id}`);
     },
     onClick() {},
     closeMenu(e) {
-      if (!this.$el.querySelector(`#open-button-${this.article.id}`).contains(e.target)) {
+      if (this.ownedByMe && !this.$el.querySelector(`#open-button-${this.article.id}`).contains(e.target)) {
         this.isShown = false;
       }
     },


### PR DESCRIPTION
* 自身のマイページ以外の"/articles"では"#open-button-xxx"が存在しないのでpush()がうまく動作しなかった不具合を修正しました。