### PR TITLE
[update]#186 Updated Likes.vue

### DIFF
--- a/laravel/resources/js/pages/userPage/Likes.test.js
+++ b/laravel/resources/js/pages/userPage/Likes.test.js
@@ -35,19 +35,26 @@ const { current_page, per_page, last_page } = {
 };
 
 let response = null;
-let userpage = null;
+let [userpage, auth] = [null, null];
 let wrapper = null;
-let [spyDispatch, spyRouterPush] = [null, null];
+let [spyDispatch, spyCommit, spyRouterPush] = [null, null, null];
 beforeEach(async () => {
     response = responseFactory(current_page, per_page, last_page);
     userpage = {
         namespaced: true,
-        state: { likes: null },
+        state: { likes: null, articles: null, archived: null },
         mutations: {
             setLikes(state, likes) {
                 state.likes = likes;
             },
+            setArchives(state, archives) {
+                state.archives = archives;
+            },
+            setArticles(state, articles) {
+                state.articles = articles;
+            },
         },
+
         actions: {
             getLikedArticles: jest.fn().mockImplementation(context => {
                 context.commit("setLikes", response);
@@ -55,12 +62,22 @@ beforeEach(async () => {
         },
     };
 
+    auth = {
+        namespaced: true,
+        getters: { username: jest.fn().mockImplementation(() => author) },
+    };
     const router = Test.setVueRouter();
-    const store = Test.setVuex({ userpage });
+    const store = Test.setVuex({ userpage, auth });
     spyDispatch = jest.spyOn(store, "dispatch");
+    spyCommit = jest.spyOn(store, "commit");
     spyRouterPush = jest.spyOn(router, "push");
 
-    Test.setSpys({ getLikedArticles: userpage.actions.getLikedArticles, spyDispatch, spyRouterPush });
+    Test.setSpys({
+        getLikedArticles: userpage.actions.getLikedArticles,
+        spyDispatch,
+        spyCommit,
+        spyRouterPush,
+    });
     const options = {
         propsData: { page: current_page, username: author },
     };
@@ -129,6 +146,24 @@ describe("メソッド関連", () => {
         expect(spyFetchPageData).not.toHaveBeenCalled();
     });
 
+    it.each([
+        ["this.username === this.loginUsername && this.isChangedがtrue", "実行される", true],
+        ["this.username === this.loginUsername && this.isChangedがfalse", "実行されない", false],
+    ])("%sでbeforeRouteLeave()が実行されたらsetArticlesとsetLikesが%s", (_, __, isChanged) => {
+        spyCommit.mock.calls = [];
+        wrapper.setData({ isChanged });
+        expect(spyCommit).not.toHaveBeenCalled();
+        Likes.beforeRouteLeave.call(wrapper.vm, null, null, jest.fn());
+        if (isChanged) {
+            expect(spyCommit.mock.calls).toEqual([
+                ["userpage/setArticles", null, { root: true }],
+                ["userpage/setLikes", null, { root: true }],
+            ]);
+        } else {
+            expect(spyCommit).not.toHaveBeenCalled();
+        }
+    });
+
     describe("いいね関連", () => {
         it("changeLikeイベントが発火されたらonChangeLike()が実行される", () => {
             expect(spyOnChangeLike).not.toHaveBeenCalled();
@@ -142,11 +177,13 @@ describe("メソッド関連", () => {
         it.each([[false], [true]])("onChangeLike()がisLiked: %sで実行されたらpageDataが反映される", isLiked => {
             response.data[0].liked_by_me = !isLiked;
             const e = { id: response.data[0].id, isLiked };
+            expect(wrapper.vm.$data.isChanged).toBe(false);
             wrapper.vm.$data.pageData.forEach((article, index) => {
                 expect(article.likes_count).toBe(10);
                 expect(article.liked_by_me).toBe(index === 0 ? !isLiked : false);
             });
             wrapper.vm.onChangeLike(e);
+            expect(wrapper.vm.$data.isChanged).toBe(true);
             wrapper.vm.$data.pageData.forEach((article, index) => {
                 const likes_count = isLiked ? 11 : 9;
                 expect(article.likes_count).toBe(index === 0 ? likes_count : 10);
@@ -179,6 +216,25 @@ describe("メソッド関連", () => {
                 });
             }
         );
+
+        it.each([
+            ["this.username === this.loginUsername", "実行される", true],
+            ["this.username !== this.loginUsername", "実行されない", false],
+        ])("onChangeArchive()が%sで実行されたらsetArchivesが%s", async (_, __, isMyPage) => {
+            spyCommit.mock.calls = [];
+            const e = { id: response.data[0].id, isArchived: true };
+            if (!isMyPage) {
+                await wrapper.setProps({ username: randomStr() });
+            }
+
+            expect(spyCommit).not.toHaveBeenCalled();
+            wrapper.vm.onChangeArchive(e);
+            if (isMyPage) {
+                expect(spyCommit.mock.calls).toEqual([["userpage/setArchives", null, { root: true }]]);
+            } else {
+                expect(spyCommit).not.toHaveBeenCalled();
+            }
+        });
     });
 });
 


### PR DESCRIPTION
* ページから離れた際に条件を満たしていればとuserpageモジュールのarticlesとlikesをリセットする処理を追加しました。
* userpageモジュールのlikesがnullに変更されたら実行されるウォッチャを追加しました。
* マイページの時にonChangeArchive()が実行されるとuserpageモジュールのarchivesがリセットされる処理を追加しました。